### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Add the following piece (no pun intended) of code before the closing ```</body>``` tag on your website to promote **PEACE.JS**:
 
 ```html
-<script src="https://cdn.jsdelivr.net/peace.js/1.1.4/peace.min.js" async></script>
+<script src="https://cdn.jsdelivr.net/gh/humancopy/peace.js@1.1.4/dist/peace.min.js" async></script>
 ```
 
 *You can actually paste it anywhere inside the ```<body>```. It will inject itself at the same DOM level as the ```<script>``` tag.*
@@ -13,7 +13,7 @@ Add the following piece (no pun intended) of code before the closing ```</body>`
 By default **PEACE.JS** will be appeneded to the parent element of the ```<script>``` tag. If you'd like to inject it somewhere else simply add the `data-target` attribute:
 
 ```html
-<script src="https://cdn.jsdelivr.net/peace.js/1.1.4/peace.min.js" data-target="#footer" async></script>
+<script src="https://cdn.jsdelivr.net/gh/humancopy/peace.js@1.1.4/dist/peace.min.js" data-target="#footer" async></script>
 ```
 
 ## Themes
@@ -21,7 +21,7 @@ By default **PEACE.JS** will be appeneded to the parent element of the ```<scrip
 The default text color for **PEACE.JS** is black. This can be controlled via the `data-theme` attribute. Possible values are: black, white, green & blue.
 
 ```html
-<script src="https://cdn.jsdelivr.net/peace.js/1.1.4/peace.min.js" data-theme="blue" async></script>
+<script src="https://cdn.jsdelivr.net/gh/humancopy/peace.js@1.1.4/dist/peace.min.js" data-theme="blue" async></script>
 ```
 
 ## Style
@@ -29,7 +29,7 @@ The default text color for **PEACE.JS** is black. This can be controlled via the
 By default **PEACE.JS** will show the word Peace in different languages. If you prefer instead to show a peace symbol simply add the `data-stlye="symbol"` attribute to the script tag:
 
 ```html
-<script src="https://cdn.jsdelivr.net/peace.js/1.1.4/peace.min.js" data-style="symbol" async></script>
+<script src="https://cdn.jsdelivr.net/gh/humancopy/peace.js@1.1.4/dist/peace.min.js" data-style="symbol" async></script>
 ```
 
 ## Autoloading


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/humancopy/peace.js.

Feel free to ping me if you have any questions regarding this change.